### PR TITLE
Fixing BungieAccountData formatting from API

### DIFF
--- a/lib/api/models/bungie_account.dart
+++ b/lib/api/models/bungie_account.dart
@@ -9,11 +9,11 @@ class BungieAccountData {
   BungieAccountData({
     required this.bungieGlobalDisplayName,
     required this.bungieGlobalDisplayNameCode,
-    required this.bungieNetMembershipId,
+    String? bungieMembershipId,
     List<DestinyMembership>? memberships
-  }) : memberships = memberships ?? [];
+  }) : bungieNetMembershipId = bungieMembershipId ?? "", memberships = memberships ?? [];
 
-  String get getFullBungieId => "$bungieGlobalDisplayName#$bungieGlobalDisplayNameCode";
+  String get fullBungieId => "$bungieGlobalDisplayName#$bungieGlobalDisplayNameCode";
 
   bool get isCrossSavedAccount =>
     memberships!.length > 1 && memberships!.every((element) => element.overrideType != 0);
@@ -27,9 +27,11 @@ class BungieAccountData {
     :
       bungieGlobalDisplayName = json["bungieGlobalDisplayName"],
       bungieGlobalDisplayNameCode = json["bungieGlobalDisplayNameCode"],
-      bungieNetMembershipId = json["bungieNetMembershipId"],
-      memberships = json["destinyMemberships"] != null ? List<DestinyMembership>.from(json["destinyMemberships"].map((membership) =>
-        DestinyMembership.fromJson(membership))
+      bungieNetMembershipId = json["bungieNetMembershipId"] ?? "",
+      memberships = json["destinyMemberships"] != null ? List<DestinyMembership>.from(
+        json["destinyMemberships"].map((membership) =>
+          DestinyMembership.fromJson(membership)
+        )
       ) : [];
 
   Map<String, dynamic> toJson() =>

--- a/lib/api/search.dart
+++ b/lib/api/search.dart
@@ -1,8 +1,9 @@
-import 'dart:io';
+import 'dart:developer';
 import 'dart:convert';
+import 'dart:io';
 
-import 'package:guardian_dock/api/client_api.dart';
 import 'package:guardian_dock/api/models/bungie_account.dart';
+import 'package:guardian_dock/api/client_api.dart';
 
 class Search {
   final ApiClient _client;
@@ -19,6 +20,7 @@ class Search {
     if (response.statusCode >= 400) {
       throw HttpException(response.body);
     }
+    log(response.body);
     return List<BungieAccountData>.from(jsonDecode(utf8.decode(response.bodyBytes))['Response']['searchResults'].map((account) => BungieAccountData.fromJson(account)));
   }
 }


### PR DESCRIPTION
Variable bungieNetMembershipId in the BungieAccountData data class could be nullable as shown below:

```json
      {
        "bungieGlobalDisplayName": "Aled",
        "bungieGlobalDisplayNameCode": 2824, // <= When formatting, API thinks that bungieNetMembershipId always exists, but here it doesn't
        "destinyMemberships": [
          {
            "iconPath": "/img/theme/destiny/icons/icon_stadia.png",
            "crossSaveOverride": 0,
            "applicableMembershipTypes": [
              5
            ],
            "isPublic": true,
            "membershipType": 5,
            "membershipId": "4611686018521659565",
            "displayName": "Aled#2754",
            "bungieGlobalDisplayName": "Aled",
            "bungieGlobalDisplayNameCode": 2824
          }
        ]
      },
      {
        "bungieGlobalDisplayName": "ALED",
        "bungieGlobalDisplayNameCode": 3064,
        "bungieNetMembershipId": "31142636", // <= Compared here
        "destinyMemberships": [
          {
            "iconPath": "/img/theme/bungienet/icons/steamLogo.png",
            "crossSaveOverride": 0,
            "applicableMembershipTypes": [
              3
            ],
            "isPublic": true,
            "membershipType": 3,
            "membershipId": "4611686018526693254",
            "displayName": "KREKKX",
            "bungieGlobalDisplayName": "ALED",
            "bungieGlobalDisplayNameCode": 3064
          }
        ]
      },
```

Thus, I just had to make [bungieMembershipId nullable](https://github.com/0Nom4D/GuardianDock/blob/account_search_error_fix/lib/api/models/bungie_account.dart#L12) and not mandatory for the BungieAccountData class to be created.
Same thing in the [fromJson static function](https://github.com/0Nom4D/GuardianDock/blob/account_search_error_fix/lib/api/models/bungie_account.dart#L30).